### PR TITLE
Validate AWS ssh_public_keys configuration

### DIFF
--- a/aws-kubeadm/variables.tf
+++ b/aws-kubeadm/variables.tf
@@ -26,6 +26,19 @@ variable "ssh_public_keys" {
   default = {
     "key1" = { "key_file" = "~/.ssh/id_rsa.pub" },
   }
+  validation {
+    condition = (
+      (lookup(var.ssh_public_keys, "key1", "__missing__") != "__missing__") &&
+      (
+        (
+          lookup(lookup(var.ssh_public_keys, "key1"), "key_file", "__missing__") == "__missing__" ? false : length(regexall("^ssh-rsa .*", file(lookup(lookup(var.ssh_public_keys, "key1"), "key_file")))) > 0
+          ) || (
+          lookup(lookup(var.ssh_public_keys, "key1"), "key_data", "__missing__") == "__missing__" ? false : length(regexall("^ssh-rsa .*", lookup(lookup(var.ssh_public_keys, "key1"), "key_data"))) > 0
+        )
+      )
+    )
+    error_message = "For AWS ssh_public_keys variable must contain key named `key1` with an RSA key."
+  }
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
With default config currently fails with

```
Error: Invalid function argument

  on variables.tf line 31, in variable "ssh_public_keys":
  31:       (lookup(var.ssh_public_keys, "key1", "__missing__") != "__missing__") &&

Invalid value for "default" parameter: the default value must have the same
type as the map elements.
```