### PR TITLE
First try porting install-metrics_server.tf from hcloud

### DIFF
--- a/aws-kubeadm/main.tf
+++ b/aws-kubeadm/main.tf
@@ -5,11 +5,13 @@ module "k8s" {
   num_workers  = var.num_workers
 
   aws_instance_root_size_gb = var.aws_instance_root_size_gb
-  aws_region                = var.aws_region
   aws_instance_type_worker  = var.aws_instance_type_worker
+  aws_region                = var.aws_region
   docker_version            = var.docker_version
   flannel_version           = var.flannel_version
   kubernetes_version        = var.kubernetes_version
+  metrics_server_version    = var.metrics_server_version
+  server_upload_dir         = var.server_upload_dir
 
   ssh_public_keys = var.ssh_public_keys
 
@@ -39,6 +41,6 @@ module "mayastor" {
   mayastor_replicas           = var.mayastor_replicas
   mayastor_use_develop_images = var.mayastor_use_develop_images
   node_names                  = [for worker in slice(module.k8s.cluster_nodes, 1, length(module.k8s.cluster_nodes)) : worker.name]
-  server_upload_dir           = "/root/tf-upload"
+  server_upload_dir           = var.server_upload_dir
   source                      = "./modules/mayastor"
 }

--- a/aws-kubeadm/modules/k8s/install-metrics-server.tf
+++ b/aws-kubeadm/modules/k8s/install-metrics-server.tf
@@ -1,0 +1,39 @@
+# FIXME: fix auth to kubelet and don't use --deprecated-kubelet-completely-insecure
+resource "null_resource" "metrics_server" {
+  depends_on = [aws_instance.master, aws_instance.workers]
+  triggers = {
+    k8s_master_ip          = aws_eip.master.public_ip
+    metrics_server_version = var.metrics_server_version
+    server_upload_dir      = var.server_upload_dir
+
+    # FIXME: put hostnames to some variable, it's really generated in aws_instance.* machine-bootstrap.sh template
+    patch_yaml = templatefile("${path.module}/templates/metrics_server_patch.yaml.tmpl", {
+      "master" : "${var.cluster_name}-${aws_instance.master.tags["terraform-kubeadm:node"]}",
+      "master_ip" : aws_instance.master.private_ip,
+      "node_ips" : [for node in aws_instance.workers : node.private_ip],
+      "nodes" : [for node in aws_instance.workers : "${var.cluster_name}-${node.tags["terraform-kubeadm:node"]}"],
+    })
+  }
+  connection {
+    host = self.triggers.k8s_master_ip
+  }
+
+  provisioner "file" {
+    content     = self.triggers.patch_yaml
+    destination = "${self.triggers.server_upload_dir}/metrics_server_patch.yaml"
+  }
+
+  provisioner "remote-exec" {
+    inline = ["kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v${self.triggers.metrics_server_version}/components.yaml"]
+  }
+
+  provisioner "remote-exec" {
+    inline = ["kubectl -n kube-system patch deployment metrics-server --patch \"$(cat ${self.triggers.server_upload_dir}/metrics_server_patch.yaml)\""]
+  }
+
+  provisioner "remote-exec" {
+    when   = destroy
+    inline = ["kubectl delete -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v${self.triggers.metrics_server_version}/components.yaml"]
+  }
+}
+

--- a/aws-kubeadm/modules/k8s/templates/metrics_server_patch.yaml.tmpl
+++ b/aws-kubeadm/modules/k8s/templates/metrics_server_patch.yaml.tmpl
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      hostAliases:
+      - ip: ${master_ip}
+        hostnames:
+        - ${master}
+%{ for index,name in nodes ~}
+      - ip: ${node_ips[index]}
+        hostnames:
+        - ${name}
+%{ endfor ~}
+      containers:
+        - name: metrics-server
+          args:
+          - --cert-dir=/tmp
+          - --secure-port=4443
+          - --kubelet-port=10255
+          - --deprecated-kubelet-completely-insecure

--- a/aws-kubeadm/modules/k8s/variables.tf
+++ b/aws-kubeadm/modules/k8s/variables.tf
@@ -87,6 +87,11 @@ variable "kubernetes_version" {
   description = "Kubernetes version to install."
 }
 
+variable "metrics_server_version" {
+  type        = string
+  description = "Metrics server version to install."
+}
+
 variable "ebs_volume_size" {
   type        = number
   description = "Additional EBS volume size to attach to EC2 instance on workers in gigabytes."
@@ -121,5 +126,10 @@ variable "aws_worker_instances" {
     "t3.xlarge" : "/dev/nvme1n1",
     "i3.xlarge" : "/dev/nvme0n1",
   }
+}
+
+variable "server_upload_dir" {
+  type        = string
+  description = "Terraform provisioner remote-exec sometimes need to put files to a remote machine. It's uploaded into server_upload_dir."
 }
 

--- a/aws-kubeadm/variables.tf
+++ b/aws-kubeadm/variables.tf
@@ -58,6 +58,12 @@ variable "kubernetes_version" {
   default     = "1.19.4"
 }
 
+variable "metrics_server_version" {
+  type        = string
+  description = "Metrics server version to install."
+  default     = "0.4.1"
+}
+
 variable "deploy_mayastor" {
   type        = bool
   description = "Deploy mayastor dependencies (nvme-tcp kernel module, set up hugepages) and mayastor itself. Set to false to skip."
@@ -122,3 +128,10 @@ variable "docker_insecure_registry" {
   description = "Set trusted docker registry on worker nodes (handy for private registry)"
   default     = ""
 }
+
+variable "server_upload_dir" {
+  type        = string
+  description = "Terraform provisioner remote-exec sometimes need to put files to a remote machine. It's uploaded into server_upload_dir."
+  default     = "/root/tf-upload"
+}
+


### PR DESCRIPTION
Doesn't work - classic:

```
E1214 17:44:02.743738       1 server.go:132] unable to fully scrape metrics: [unable to fully scrape metrics from node master: unable to fetch metrics from
 node master: Get "https://10.0.76.217:10250/stats/summary?only_cpu_and_memory=true": x509: cannot validate certificate for 10.0.76.217 because it doesn't
contain any IP SANs, unable to fully scrape metrics from node worker-1: unable to fetch metrics from node worker-1: Get "https://10.0.40.5:10250/stats/summ
ary?only_cpu_and_memory=true": x509: cannot validate certificate for 10.0.40.5 because it doesn't contain any IP SANs, unable to fully scrape metrics from
node worker-0: unable to fetch metrics from node worker-0: Get "https://10.0.153.26:10250/stats/summary?only_cpu_and_memory=true": x509: cannot validate ce
rtificate for 10.0.153.26 because it doesn't contain any IP SANs]
I1214 17:44:02.743900       1 requestheader_controller.go:169] Starting RequestHeaderAuthRequestController
I1214 17:44:02.743938       1 shared_informer.go:240] Waiting for caches to sync for RequestHeaderAuthRequestController
I1214 17:44:02.743985       1 configmap_cafile_content.go:202] Starting client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I1214 17:44:02.744002       1 shared_informer.go:240] Waiting for caches to sync for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I1214 17:44:02.744040       1 configmap_cafile_content.go:202] Starting client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
I1214 17:44:02.744072       1 shared_informer.go:240] Waiting for caches to sync for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
I1214 17:44:02.744752       1 secure_serving.go:197] Serving securely on [::]:4443
I1214 17:44:02.745340       1 dynamic_serving_content.go:130] Starting serving-cert::/tmp/apiserver.crt::/tmp/apiserver.key
I1214 17:44:02.745684       1 tlsconfig.go:240] Starting DynamicServingCertificateController
I1214 17:44:02.844095       1 shared_informer.go:247] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I1214 17:44:02.844166       1 shared_informer.go:247] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
I1214 17:44:02.844184       1 shared_informer.go:247] Caches are synced for RequestHeaderAuthRequestController
I1214 17:44:29.302028       1 requestheader_controller.go:183] Shutting down RequestHeaderAuthRequestController
I1214 17:44:29.302147       1 configmap_cafile_content.go:223] Shutting down client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
I1214 17:44:29.302224       1 configmap_cafile_content.go:223] Shutting down client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I1214 17:44:29.302376       1 tlsconfig.go:255] Shutting down DynamicServingCertificateController
```