### PR TITLE
E2E ondemand clusters.

### DIFF
--- a/aws-kubeadm/main.tf
+++ b/aws-kubeadm/main.tf
@@ -24,6 +24,7 @@ module "mayastor-dependencies" {
   source = "./modules/mayastor-dependencies"
 
   docker_insecure_registry = var.docker_insecure_registry
+  k8s_master_ip            = module.k8s.cluster_nodes[0].public_ip
 
   workers = {
     for worker in slice(module.k8s.cluster_nodes, 1, length(module.k8s.cluster_nodes)) :

--- a/hcloud-kubeadm/bin/run-fio
+++ b/hcloud-kubeadm/bin/run-fio
@@ -1,0 +1,30 @@
+#! /bin/sh
+
+set -e
+
+. "$(dirname "$0")/export-kubeconfig.sh"
+
+check_pod() {
+	# $1 - pod name
+	# $2 - yaml that would deploy pod
+
+	if ! kubectl get pods | grep -q "$1.*Running"; then
+		echo "Cannot find running pod '$1' in current cluster (using $(dirname "$0")/bin/export-kubeconfig.sh)"
+		echo "Make sure pod '$1' is in the state Running"
+		echo "You can deploy it with: kubectl apply -f $(realpath "$(dirname "$0")/../$2")"
+		exit 1
+	fi
+}
+
+
+case "$1" in
+	mayastor)
+		check_pod fio-mayastor test-pod-fio-mayastor.yaml
+		kubectl exec -it fio-mayastor -- fio --name=benchtest --size=800m --filename=/volume/test --direct=1 --rw=randrw --ioengine=libaio --bs=4k --iodepth=16 --numjobs=1 --time_based --runtime=60
+		;;
+	hcloud)
+		check_pod fio-hcloud test-pod-fio-hcloud-csi.yaml
+		kubectl exec -it fio-hcloud -- fio --name=benchtest --size=800m --filename=/volume/test --direct=1 --rw=randrw --ioengine=libaio --bs=4k --iodepth=16 --numjobs=1 --time_based --runtime=60
+		;;
+	*) echo "$0: (hcloud|mayastor)"; exit 1;;
+esac

--- a/hcloud-kubeadm/main.tf
+++ b/hcloud-kubeadm/main.tf
@@ -2,6 +2,7 @@ module "k8s" {
   source = "./modules/k8s"
 
   admin_ssh_keys    = var.admin_ssh_keys
+  cluster_name      = var.cluster_name
   hcloud_csi_token  = var.hcloud_csi_token
   hcloud_token      = var.hcloud_token
   hetzner_location  = var.hetzner_location

--- a/hcloud-kubeadm/main.tf
+++ b/hcloud-kubeadm/main.tf
@@ -16,6 +16,7 @@ module "mayastor-dependencies" {
   source = "./modules/mayastor-dependencies"
 
   docker_insecure_registry = var.docker_insecure_registry
+  k8s_master_ip            = module.k8s.master_ip
 
   workers = {
     for worker in slice(module.k8s.cluster_nodes, 1, length(module.k8s.cluster_nodes)) :

--- a/hcloud-kubeadm/main.tf
+++ b/hcloud-kubeadm/main.tf
@@ -3,6 +3,7 @@ module "k8s" {
 
   admin_ssh_keys    = var.admin_ssh_keys
   cluster_name      = var.cluster_name
+  existing_ssh_keys = var.existing_ssh_keys
   hcloud_csi_token  = var.hcloud_csi_token
   hcloud_token      = var.hcloud_token
   hetzner_location  = var.hetzner_location

--- a/hcloud-kubeadm/modules/k8s/main.tf
+++ b/hcloud-kubeadm/modules/k8s/main.tf
@@ -10,12 +10,12 @@ provider "kubernetes" {
 
 resource "hcloud_ssh_key" "admin_ssh_keys" {
   for_each   = var.admin_ssh_keys
-  name       = each.key
+  name       = "${each.key}-${var.cluster_name}"
   public_key = lookup(each.value, "key_file", "__missing__") == "__missing__" ? lookup(each.value, "key_data") : file(lookup(each.value, "key_file"))
 }
 
 resource "hcloud_server" "master" {
-  name        = "master"
+  name        = "master-${var.cluster_name}"
   server_type = var.master_type
   image       = var.master_image
   ssh_keys    = [for key in hcloud_ssh_key.admin_ssh_keys : key.id]
@@ -74,7 +74,7 @@ resource "hcloud_server" "master" {
 
 resource "hcloud_server" "node" {
   count       = var.node_count
-  name        = "node-${count.index + 1}"
+  name        = "node-${count.index}-${var.cluster_name}"
   server_type = var.node_type
   image       = var.node_image
   depends_on  = [hcloud_server.master]

--- a/hcloud-kubeadm/modules/k8s/main.tf
+++ b/hcloud-kubeadm/modules/k8s/main.tf
@@ -14,11 +14,17 @@ resource "hcloud_ssh_key" "admin_ssh_keys" {
   public_key = lookup(each.value, "key_file", "__missing__") == "__missing__" ? lookup(each.value, "key_data") : file(lookup(each.value, "key_file"))
 }
 
+// include keys configured in the project with label "admin"
+data "hcloud_ssh_key" "existing_ssh_keys" {
+  for_each = toset(var.existing_ssh_keys)
+  name     = each.key
+}
+
 resource "hcloud_server" "master" {
   name        = "master-${var.cluster_name}"
   server_type = var.master_type
   image       = var.master_image
-  ssh_keys    = [for key in hcloud_ssh_key.admin_ssh_keys : key.id]
+  ssh_keys    = concat([for key in hcloud_ssh_key.admin_ssh_keys : key.id], [for key in data.hcloud_ssh_key.existing_ssh_keys : key.id])
   location    = var.hetzner_location
 
   connection {
@@ -78,7 +84,7 @@ resource "hcloud_server" "node" {
   server_type = var.node_type
   image       = var.node_image
   depends_on  = [hcloud_server.master]
-  ssh_keys    = [for key in hcloud_ssh_key.admin_ssh_keys : key.id]
+  ssh_keys    = concat([for key in hcloud_ssh_key.admin_ssh_keys : key.id], [for key in data.hcloud_ssh_key.existing_ssh_keys : key.id])
   location    = var.hetzner_location
 
   // FIXME: re-create node on change in the scripts content; triggers do not work here

--- a/hcloud-kubeadm/modules/k8s/variables.tf
+++ b/hcloud-kubeadm/modules/k8s/variables.tf
@@ -25,3 +25,8 @@ variable "pod_network_cidr" { default = "10.244.0.0/16" }
 variable "metrics_server_version" { default = "0.3.7" }
 
 variable "install_packages" { description = "Additional deb packages to install during instance bootstrap." }
+
+variable "cluster_name" {
+  type        = string
+  description = "Cluster name. Used as a suffix for SSH keys, node names and volumes."
+}

--- a/hcloud-kubeadm/modules/k8s/variables.tf
+++ b/hcloud-kubeadm/modules/k8s/variables.tf
@@ -30,3 +30,8 @@ variable "cluster_name" {
   type        = string
   description = "Cluster name. Used as a suffix for SSH keys, node names and volumes."
 }
+
+variable "existing_ssh_keys" {
+  type        = list(string)
+  description = "Use following keys (by name) from HCloud project. Keys must already exist in the project."
+}

--- a/hcloud-kubeadm/modules/mayastor-dependencies/main.tf
+++ b/hcloud-kubeadm/modules/mayastor-dependencies/main.tf
@@ -24,3 +24,21 @@ resource "null_resource" "mayastor_dependencies" {
   }
 }
 
+// Set label openebs.io/engine=mayastor on all cluster nodes - we want to run MSN on all nodes
+resource "null_resource" "mayastor_node_label" {
+  for_each = toset(keys(var.workers))
+  triggers = {
+    k8s_master_ip = var.k8s_master_ip
+  }
+  connection {
+    host = self.triggers.k8s_master_ip
+  }
+  provisioner "remote-exec" {
+    inline = ["kubectl label node \"${each.key}\" openebs.io/engine=mayastor"]
+  }
+  provisioner "remote-exec" {
+    when   = destroy
+    inline = ["kubectl label node \"${each.key}\" openebs.io/engine-"]
+  }
+}
+

--- a/hcloud-kubeadm/modules/mayastor-dependencies/variables.tf
+++ b/hcloud-kubeadm/modules/mayastor-dependencies/variables.tf
@@ -14,3 +14,5 @@ variable "docker_insecure_registry" {
   description = "Set trusted docker registry on worker nodes (handy for private registry)"
   default     = ""
 }
+
+variable "k8s_master_ip" {}

--- a/hcloud-kubeadm/modules/mayastor/main.tf
+++ b/hcloud-kubeadm/modules/mayastor/main.tf
@@ -28,27 +28,8 @@ resource "null_resource" "server_upload_dir" {
   }
 }
 
-// Set label openebs.io/engine=mayastor on all cluster nodes - we want to run MSN on all nodes
-resource "null_resource" "mayastor_node_label" {
-  for_each = toset(var.node_names)
-  triggers = {
-    k8s_master_ip = var.k8s_master_ip
-  }
-  connection {
-    host = self.triggers.k8s_master_ip
-  }
-  provisioner "remote-exec" {
-    inline = ["kubectl label node \"${each.key}\" openebs.io/engine=mayastor"]
-  }
-  provisioner "remote-exec" {
-    when   = destroy
-    inline = ["kubectl label node \"${each.key}\" openebs.io/engine-"]
-  }
-}
-
 // FIXME it would be nice to have yamls in HCL; but rather to have them in mayadata repo as snippets or TF module
 resource "null_resource" "mayastor" {
-  depends_on = [null_resource.mayastor_node_label]
   triggers = {
     k8s_master_ip      = var.k8s_master_ip
     mayastor_image_tag = var.mayastor_use_develop_images ? "develop" : "master"

--- a/hcloud-kubeadm/variables.tf
+++ b/hcloud-kubeadm/variables.tf
@@ -76,3 +76,8 @@ variable "docker_insecure_registry" {
   description = "Set trusted docker registry on worker nodes (handy for private registry)"
   default     = ""
 }
+
+variable "cluster_name" {
+  type        = string
+  description = "Cluster name. Used as a suffix for SSH keys, node names and volumes."
+}

--- a/hcloud-kubeadm/variables.tf
+++ b/hcloud-kubeadm/variables.tf
@@ -29,6 +29,12 @@ variable "admin_ssh_keys" {
   }
 }
 
+variable "existing_ssh_keys" {
+  type        = list(string)
+  description = "Use following keys (by name) from HCloud project. Keys must already exist in the project."
+  default     = []
+}
+
 variable "mayastor_use_develop_images" {
   type        = bool
   description = "Deploy 'develop' version of Mayastor instead of latest release. Beware, here be dragons!"


### PR DESCRIPTION
Changes required to run Mayastor e2e tests on clusters created by this terraform.

* all: move labeling of mayastor nodes to mayastor-dependencies module
* hcloud: templatize names to allow multiple clusters
* hcloud: allow using existing ssh keys from hcloud project
* hcloud: add run-fio script fio "wrapper" for quick test

ref: CAS-570