### PR TITLE
hcloud,aws: parametrize cluster more; k8s,docker,kernel upgrade

### DIFF
--- a/aws-kubeadm/main.tf
+++ b/aws-kubeadm/main.tf
@@ -25,6 +25,7 @@ module "mayastor-dependencies" {
 
   docker_insecure_registry = var.docker_insecure_registry
   k8s_master_ip            = module.k8s.cluster_nodes[0].public_ip
+  kernel_version           = var.kernel_version
 
   workers = {
     for worker in slice(module.k8s.cluster_nodes, 1, length(module.k8s.cluster_nodes)) :

--- a/aws-kubeadm/variables.tf
+++ b/aws-kubeadm/variables.tf
@@ -49,13 +49,13 @@ variable "flannel_version" {
 variable "docker_version" {
   type        = string
   description = "Docker version to install."
-  default     = "19.03"
+  default     = "20.0.5"
 }
 
 variable "kubernetes_version" {
   type        = string
   description = "Kubernetes version to install."
-  default     = "1.19.4"
+  default     = "1.20.4"
 }
 
 variable "deploy_mayastor" {
@@ -121,4 +121,9 @@ variable "docker_insecure_registry" {
   type        = string
   description = "Set trusted docker registry on worker nodes (handy for private registry)"
   default     = ""
+}
+
+variable "kernel_version" {
+  description = "Which kernel version to install. Must be a version available in used ubuntu version. A linux-modules-extra must exist for that version."
+  default     = "5.8.0-44-generic"
 }

--- a/hcloud-kubeadm/main.tf
+++ b/hcloud-kubeadm/main.tf
@@ -1,14 +1,17 @@
 module "k8s" {
   source = "./modules/k8s"
 
-  admin_ssh_keys    = var.admin_ssh_keys
-  cluster_name      = var.cluster_name
-  existing_ssh_keys = var.existing_ssh_keys
-  hcloud_csi_token  = var.hcloud_csi_token
-  hcloud_token      = var.hcloud_token
-  hetzner_location  = var.hetzner_location
-  node_count        = var.node_count
-  server_upload_dir = var.server_upload_dir
+  admin_ssh_keys     = var.admin_ssh_keys
+  cluster_name       = var.cluster_name
+  docker_version     = var.docker_version
+  existing_ssh_keys  = var.existing_ssh_keys
+  hcloud_csi_token   = var.hcloud_csi_token
+  hcloud_token       = var.hcloud_token
+  hetzner_location   = var.hetzner_location
+  kubernetes_version = var.kubernetes_version
+  node_count         = var.node_count
+  node_type          = var.node_type
+  server_upload_dir  = var.server_upload_dir
 
   install_packages = var.install_packages
 }
@@ -18,6 +21,8 @@ module "mayastor-dependencies" {
 
   docker_insecure_registry = var.docker_insecure_registry
   k8s_master_ip            = module.k8s.master_ip
+  kernel_version           = var.kernel_version
+  nr_hugepages             = var.nr_hugepages
 
   workers = {
     for worker in slice(module.k8s.cluster_nodes, 1, length(module.k8s.cluster_nodes)) :

--- a/hcloud-kubeadm/modules/k8s/variables.tf
+++ b/hcloud-kubeadm/modules/k8s/variables.tf
@@ -10,10 +10,10 @@ variable "master_image" { default = "ubuntu-20.04" }
 variable "master_type" { default = "cx21" }
 variable "node_count" {}
 variable "node_image" { default = "ubuntu-20.04" }
-variable "node_type" { default = "cpx21" }
+variable "node_type" {}
 
-variable "docker_version" { default = "19.03" }
-variable "kubernetes_version" { default = "1.18.9" }
+variable "docker_version" {}
+variable "kubernetes_version" {}
 variable "feature_gates" {
   description = "Add Feature Gates e.g. 'DynamicKubeletConfig=true'"
   default     = ""

--- a/hcloud-kubeadm/modules/mayastor-dependencies/main.tf
+++ b/hcloud-kubeadm/modules/mayastor-dependencies/main.tf
@@ -13,14 +13,15 @@ resource "null_resource" "mayastor_dependencies" {
       "set -xve",
       "echo \"${self.triggers.nr_hugepages}\" > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages",
       "echo \"vm.nr_hugepages = ${self.triggers.nr_hugepages}\" > /etc/sysctl.d/10-mayastor-hugepages.conf",
-      "apt-get -qy update && apt-get -qy install linux-modules-extra-5.8.0-43-generic",
+      "apt-get -qy update && apt-get -qy install linux-modules-extra-${self.triggers.kernel_version}",
       "echo 'nvme-tcp' >> /etc/modules",
       "systemd-run /bin/sh -c 'sleep 1 && reboot'", # needed to surely get the hugepages right after boot
     ]
   }
 
   triggers = {
-    nr_hugepages = var.nr_hugepages
+    nr_hugepages   = var.nr_hugepages
+    kernel_version = var.kernel_version
   }
 }
 

--- a/hcloud-kubeadm/modules/mayastor-dependencies/variables.tf
+++ b/hcloud-kubeadm/modules/mayastor-dependencies/variables.tf
@@ -16,3 +16,8 @@ variable "docker_insecure_registry" {
 }
 
 variable "k8s_master_ip" {}
+
+variable "kernel_version" {
+  description = "Which kernel version to install. Must be a version available in used ubuntu version. A linux-modules-extra must exist for that version."
+}
+

--- a/hcloud-kubeadm/variables.tf
+++ b/hcloud-kubeadm/variables.tf
@@ -87,3 +87,30 @@ variable "cluster_name" {
   type        = string
   description = "Cluster name. Used as a suffix for SSH keys, node names and volumes."
 }
+
+variable "kubernetes_version" {
+  description = "Which kubernetes version to install"
+  default     = "1.20.4"
+}
+
+variable "docker_version" {
+  description = "Which docker version to use for kubernetes"
+  default     = "20.0.5"
+}
+
+variable "node_type" {
+  description = "Which node type to use. See https://www.hetzner.com/cloud"
+  default     = "cpx21"
+}
+
+variable "kernel_version" {
+  description = "Which kernel version to install. Must be a version available in used ubuntu version. A linux-modules-extra must exist for that version."
+  default     = "5.8.0-44-generic"
+}
+
+variable "nr_hugepages" {
+  type        = number
+  description = "Number of 2MB hugepages to allocate on the worker node"
+  default     = 1024
+}
+


### PR DESCRIPTION
Allow setting following variables in top-level module:

* docker_version
* hugepages count
* kernel_version
* kubernetes_version
* node_type

Add kernel_version which is now required to AWS variables.

Upgrade kernel, docker and kubernetes.

MQ-242